### PR TITLE
TaskId: TRE-35 (1) enable payment polling before QR is generated on staff checkout page 

### DIFF
--- a/app/order-ui/src/app/client/payment/page.tsx
+++ b/app/order-ui/src/app/client/payment/page.tsx
@@ -89,6 +89,9 @@ export function ClientPaymentPage() {
       } else if (orderData?.payment && !qrCode && orderData.payment.amount === orderData.subtotal) {
         // Case 3: Payment exists but no QR code (amount < 2000) - start polling
         setIsPolling(true)
+      } else if (!orderData?.payment) {
+        // Case 4: No payment exists yet - start polling to wait for payment creation
+        setIsPolling(true)
       } else {
         setIsPolling(false)
       }

--- a/app/order-ui/src/app/system/payment/payment-page.tsx
+++ b/app/order-ui/src/app/system/payment/payment-page.tsx
@@ -99,6 +99,9 @@ export default function PaymentPage() {
       } else if (orderData?.payment && !qrCode && orderData.payment.amount === orderData.subtotal) {
         // Case 3: Payment exists but no QR code (amount < 2000) - start polling
         setIsPolling(true)
+      } else if (!orderData?.payment) {
+        // Case 4: No payment exists yet - start polling to wait for payment creation
+        setIsPolling(true)
       } else {
         setIsPolling(false)
       }

--- a/app/order-ui/src/components/app/tabscontent/customer-order.tabscontent.tsx
+++ b/app/order-ui/src/components/app/tabscontent/customer-order.tabscontent.tsx
@@ -185,7 +185,7 @@ export default function CustomerOrderTabsContent({
                       <div className="flex gap-2 sm:mt-0">
                         <CancelOrderDialog order={orderItem} />
                         <Button
-                          disabled={moment(orderItem.createdAt).isBefore(moment().subtract(10, 'minutes'))}
+                          disabled={moment(orderItem.createdAt).isBefore(moment().subtract(15, 'minutes'))}
                           className='text-orange-500 border-orange-500 hover:text-white hover:bg-orange-500'
                           variant="outline"
                           onClick={() => handleUpdateOrder(orderItem)}


### PR DESCRIPTION
Type: Development

Description:
- Initiates payment status polling as soon as the staff enters the checkout page
- Handles cases where QR code is not yet generated
- Automatically continues polling when QR becomes available
- Stops polling once payment is completed or cancelled
- Prevents missed updates caused by late QR generation